### PR TITLE
fix: 修复 react 需要的 key 和排序异常

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -39,19 +39,19 @@ const useViewModel = (props) => {
     {
       title: 'creationTime',
       dataIndex: 'creationTime',
-      sorter: (a, b) => a - b,
+      sorter: (a, b) => a.creationTime - b.creationTime,
       render: (creationTime) => moment(creationTime).format('YYYY-MM-DD HH:mm:ss'),
     },
     {
       title: 'cpu',
       dataIndex: 'cpu',
-      sorter: (a, b) => a - b,
+      sorter: (a, b) => a.cpu.percentCPUUsage - b.cpu.percentCPUUsage,
       render: (cpu) => `${(cpu.percentCPUUsage * 100).toFixed(2)}%`,
     },
     {
       title: 'memory',
       dataIndex: 'memory',
-      sorter: (a, b) => a - b,
+      sorter: (a, b) => a.memory.workingSetSize - b.memory.workingSetSize,
       render: (memory) => filesize(memory.workingSetSize * 1024),
     },
     {
@@ -119,7 +119,7 @@ const useViewModel = (props) => {
       ipcRenderer.removeListener(eventDataChannelName, updateAppMetrics);
     };
   }, []);
-  
+
   return {
     state: {
       columns,
@@ -141,6 +141,7 @@ const StatusBoard = (props) => {
         pagination={false}
         size="small"
         tableLayout="fixed"
+        rowKey={'pid'}
       />
       <footer>
         <a
@@ -152,7 +153,7 @@ const StatusBoard = (props) => {
           }}
           href="https://github.com/xudafeng/electrom"
         >
-            Electrom
+          Electrom
         </a>
       </footer>
     </div>


### PR DESCRIPTION
问题：
1. DevTools 里面显示 React child 需要 key
2. 排序需要指定一下属性
![image](https://user-images.githubusercontent.com/2226423/127266870-31692a23-0a8a-4f98-86ee-1729d8b25c3d.png)


解决方案：
1. 添加 rowKey 为 pid
2. 只需要在 排序的时候对属性进行指定，a 和 b 获取的都是 dataSource 中的对象